### PR TITLE
Fix Pydantic Settings Import Error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ cryptography==41.0.7
 email-validator==2.1.0.post1
 async-timeout==4.0.3
 httpx==0.25.2
+pydantic-settings>=2.0.3


### PR DESCRIPTION
Update `requirements.txt` to fix pydantic settings import error.

* **Dependencies Update**
  - Add `pydantic-settings>=2.0.3` to the dependencies list.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/KrypticGadget/Fairness-Factor-Blog-Generator?shareId=bb61fdcd-8634-44fa-88a6-621689008366).